### PR TITLE
Quote lambdas with #' rather than '

### DIFF
--- a/ob-go.el
+++ b/ob-go.el
@@ -89,7 +89,7 @@
                 ;; package
                 (org-babel-go-ensure-package body)
                 ;; imports
-                (mapconcat '(lambda (pkg) (format "import %S" pkg))
+                (mapconcat #'(lambda (pkg) (format "import %S" pkg))
                            (org-babel-go-as-list imports)
                            "\n")
                 ;; variables
@@ -133,19 +133,19 @@ called by `org-babel-execute-src-block'"
                  org-babel-go-command
                  (mapconcat 'identity (org-babel-go-as-list flags) " ")
                  (org-babel-process-file-name tmp-src-file)
-                 (mapconcat '(lambda (a)
-                               ;; If there's a chance that the symbol is a
-                               ;; ref, use that. Otherwise, just return the
-                               ;; string form of the value.
-                               (format "%S" (if (symbolp a)
-                                                (let* ((ref (symbol-name a))
-                                                       (out (org-babel-read ref)))
-                                                  (if (equal out ref)
-                                                      (if (string-match "^\".*\"$" ref)
-                                                          (read ref)
-                                                        (org-babel-ref-resolve ref))
-                                                    out))
-                                              a)))
+                 (mapconcat #'(lambda (a)
+                                ;; If there's a chance that the symbol is a
+                                ;; ref, use that. Otherwise, just return the
+                                ;; string form of the value.
+                                (format "%S" (if (symbolp a)
+                                                 (let* ((ref (symbol-name a))
+                                                        (out (org-babel-read ref)))
+                                                   (if (equal out ref)
+                                                       (if (string-match "^\".*\"$" ref)
+                                                           (read ref)
+                                                         (org-babel-ref-resolve ref))
+                                                     out))
+                                               a)))
                             (org-babel-go-as-list args) " "))
          ""))))))
 


### PR DESCRIPTION
Fixes these warnings in Emacs 25.0.50.1:

```
../../.emacs.d/.cask/25.0.50.1/elpa/ob-go-20120428.2351/ob-go.el: (lambda (pkg) ...) quoted with ' rather than with #'
../../.emacs.d/.cask/25.0.50.1/elpa/ob-go-20120428.2351/ob-go.el: (lambda (a) ...) quoted with ' rather than with #'
```

Also: `(lambda)`s are self-quoting and equivalent to #'(lambda), but neither is equivalent to `'(lambda)`

See [When should Emacs #'function syntax be used?](http://stackoverflow.com/questions/16801396/when-should-emacs-function-syntax-be-used)
