### PR TITLE
Add :package option

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,15 +2,17 @@
 
 * Introduction
 
-  =ob-go= enables [[http://orgmode.org/worg/org-contrib/babel/intro.html][Org-Babel]] support for evaluating [[http://golang.org/][go]] code. It was created
-  based on the usage of [[http://orgmode.org/worg/org-contrib/babel/languages/ob-doc-C.html][ob-C]]. The go code is compiled and run via the =go run=
-  command. If a =main= function isn't present, then the coode is wrapped in a
-  simple =main= func and the package =main= is declared.
+  =ob-go= enables [[http://orgmode.org/worg/org-contrib/babel/intro.html][Org-Babel]] support for evaluating [[http://golang.org/][go]] code. It was
+  created based on the usage of [[http://orgmode.org/worg/org-contrib/babel/languages/ob-doc-C.html][ob-C]]. The go code is compiled and run
+  via the =go run= command. If a =main= function isn't present, by
+  default the code is wrapped in a simple =main= func. If =:package=
+  option isn't set and no package is declared in the code, then the
+  =main= package is declared.
 
   : #+begin_src go :imports "fmt"
   :   fmt.Println("Hello, 世界")
   : #+end_src
-  : 
+  :
   : #+resutls:
   : : Hello, 世界
 
@@ -24,10 +26,13 @@
   - =:flags= :: Flags to pass to the =go run= command. These are the flags
                   that you would pass to =go build=.
   - =:main= :: If set to =no=, inhibits the auto wrapping of the =main=
-               function call.
+               function call. Default: yes
   - =:imports= :: Shorthand for supplying imports to the app. This should be
                   used when you're letting the application handle the =main=
                   function. To supply more, use a list.
+  - =:package= :: Set the package of the file. *Requires :main no*. If
+                  not set, and code doesn't have a explicit package, then =main=
+                  package is declared.
   - =:var= :: `ob-go' also supports Babel variables with some limitations. See
               `ob-go' for more information about some of the limitations using
               =:var=.
@@ -39,7 +44,7 @@
    : #+begin_src go :imports '("fmt" "time")
    :   fmt.Println("Current Time:", time.Now())
    : #+end_src
-   : 
+   :
    : #+RESULTS:
    : : Current Time: 2012-04-29 11:47:36.933733 -0700 PDT
 
@@ -48,16 +53,16 @@
    : #+begin_src go
    :   // A concurrent prime sieve
    :   package main
-   : 
+   :
    :   import "fmt"
-   : 
+   :
    :   // Send the sequence 2, 3, 4, ... to channel 'ch'.
    :   func Generate(ch chan<- int) {
    :           for i := 2; ; i++ {
    :                   ch <- i // Send 'i' to channel 'ch'.
    :           }
    :   }
-   : 
+   :
    :   // Copy the values from channel 'in' to channel 'out',
    :   // removing those divisible by 'prime'.
    :   func Filter(in <-chan int, out chan<- int, prime int) {
@@ -68,7 +73,7 @@
    :                   }
    :           }
    :   }
-   : 
+   :
    :   // The prime sieve: Daisy-chain Filter processes.
    :   func main() {
    :           ch := make(chan int) // Create a new channel.
@@ -82,7 +87,7 @@
    :           }
    :   }
    : #+end_src
-   : 
+   :
    : #+RESULTS:
    : #+begin_example
    :   2


### PR DESCRIPTION
The option was created to make possible the use of :imports on different
packages other than main. 

Now its possible to use:

``` org
#+BEGIN_SRC go :tangle net/net_test.go :main no :package net :imports '("net" "errors" "testing")

// some code

#+END_SRC
```

The tangle generates:

``` go
package net
import "net"
import "errors"
import "testing"

// some code
```

Documentation was updated. The `:package` option requires `:main no`
