### PR TITLE
Add unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test
+
+test:
+	@rm -f .test-org-id-locations
+	emacs -Q --batch -L . -l ob-go.el -l test-ob-go.el --eval \
+		"(progn (org-reload)(setq org-confirm-babel-evaluate nil) \
+		(org-babel-do-load-languages 'org-babel-load-languages \
+		'((emacs-lisp . t) (sh . t) (org . t) (go . t))))" -f ob-go-test-runall

--- a/README.org
+++ b/README.org
@@ -101,3 +101,14 @@
    :   23
    :   29
    : #+end_example
+
+* Running tests
+
+#+BEGIN_SRC shell
+  # For Emacs earlier than 24, add -L /path/to/ert
+  emacs -Q --batch \
+        -L . -l ob-go.el -l test-ob-go.el --eval "(progn (org-reload) (setq org-confirm-babel-evaluate nil) \
+        (org-babel-do-load-languages 'org-babel-load-languages \
+        '((emacs-lisp . t) (sh . t) (org . t) (go . t))))" \
+        -f ob-go-test-runall
+#+END_SRC

--- a/README.org
+++ b/README.org
@@ -104,11 +104,13 @@
 
 * Running tests
 
+  Tests can be executed by /make test/ or invoking emacs directly with
+  the command-line below:
+
 #+BEGIN_SRC shell
   # For Emacs earlier than 24, add -L /path/to/ert
-  emacs -Q --batch \
-        -L . -l ob-go.el -l test-ob-go.el --eval "(progn (org-reload) (setq org-confirm-babel-evaluate nil) \
-        (org-babel-do-load-languages 'org-babel-load-languages \
-        '((emacs-lisp . t) (sh . t) (org . t) (go . t))))" \
-        -f ob-go-test-runall
+emacs -Q --batch -L . -l ob-go.el -l test-ob-go.el --eval \
+		"(progn (org-reload)(setq org-confirm-babel-evaluate nil) \
+		(org-babel-do-load-languages 'org-babel-load-languages \
+		'((emacs-lisp . t) (sh . t) (org . t) (go . t))))" -f ob-go-test-runall
 #+END_SRC

--- a/README.org
+++ b/README.org
@@ -108,9 +108,9 @@
   the command-line below:
 
 #+BEGIN_SRC shell
-  # For Emacs earlier than 24, add -L /path/to/ert
+# For Emacs earlier than 24, add -L /path/to/ert
 emacs -Q --batch -L . -l ob-go.el -l test-ob-go.el --eval \
-		"(progn (org-reload)(setq org-confirm-babel-evaluate nil) \
+      "(progn (org-reload)(setq org-confirm-babel-evaluate nil) \
 		(org-babel-do-load-languages 'org-babel-load-languages \
 		'((emacs-lisp . t) (sh . t) (org . t) (go . t))))" -f ob-go-test-runall
 #+END_SRC

--- a/ob-go.el
+++ b/ob-go.el
@@ -62,11 +62,18 @@
 ;;   package declaration.
 
 ;;; Code:
-;;;(require 'go-mode)
 (require 'org)
 (require 'ob)
 (require 'ob-eval)
 (require 'ob-ref)
+
+(defun ob-go-get-var (params)
+  "org-babel-get-header was removed in org version 8.3.3"
+  (let* ((fversion (org-version))
+        (version (string-to-int fversion)))
+    (if (< version 8.3)
+        (mapcar #'cdr (org-babel-get-header params :var))
+      (org-babel--get-vars params))))
 
 
 ;; optionally define a file extension for this language
@@ -82,7 +89,7 @@
 
 (defun org-babel-expand-body:go (body params &optional processed-params)
   "Expand BODY according to PARAMS, return the expanded body."
-  (let ((vars (mapcar #'cdr (org-babel--get-vars params)))
+  (let ((vars (ob-go-get-var params))
         (main-p (not (string= (cdr (assoc :main params)) "no")))
         (imports (or (cdr (assoc :imports params))
                      (org-babel-read (org-entry-get nil "imports" t))))
@@ -202,19 +209,6 @@ specifying a var of the same value."
   "If the results look like a table, then convert them into an
 Emacs-lisp table, otherwise return the results as a string."
   (org-babel-script-escape results))
-
-;; Unit Testing
-
-(defvar org-babel-go-runtests nil)
-
-(eval-when-compile
-  ;; skips tests if go isn't correctly installed
-  (let ((go-version (shell-command-to-string "go version")))
-    (setq org-babel-go-runtests (string-match "go version .*" go-version))))
-
-;; (not  (or (string-match ".* command not found" (shell-command-to-string "go2 version"))
-;;           (string-match ".*not found" go-version)))
-
 
 (provide 'ob-go)
 ;;; ob-go.el ends here

--- a/ob-go.el
+++ b/ob-go.el
@@ -5,8 +5,7 @@
 ;; Author: K. Adam Christensen
 ;; Keywords: golang, go, literate programming, reproducible research
 ;; Homepage: http://orgmode.org
-;; Version: 0.01
-;; Package-Requires: ((go-mode "1.0.0"))
+;; Version: 0.02
 
 ;;; License:
 
@@ -46,11 +45,12 @@
 ;;; Requirements:
 
 ;; - You must have go1 installed and the go should be in your `exec-path'. If
-;;   not, feel free to modify `org-babel-go-compiler' to the location of your
+;;   not, feel free to modify `org-babel-go-command' to the location of your
 ;;   go command.
 ;;
-;; - `go-mode' is also needed for syntax highlighting and formatting. Not this
-;;   this partucularly needs it, it just assumes you have it.
+;; - `go-mode' is also recommended for syntax highlighting and
+;;   formatting. Not this particularly needs it, it just assumes you
+;;   have it.
 
 ;;; TODO:
 
@@ -67,21 +67,13 @@
 (require 'ob-eval)
 (require 'ob-ref)
 
-(defun ob-go-get-var (params)
-  "org-babel-get-header was removed in org version 8.3.3"
-  (let* ((fversion (org-version))
-        (version (string-to-int fversion)))
-    (if (< version 8.3)
-        (mapcar #'cdr (org-babel-get-header params :var))
-      (org-babel--get-vars params))))
-
 
 ;; optionally define a file extension for this language
 (add-to-list 'org-babel-tangle-lang-exts '("go" . "go"))
 
 (defvar org-babel-default-header-args:go '())
 
-(defvar org-babel-go-compiler "go"
+(defvar org-babel-go-command "go"
   "The go command to use to compile and run the go code.")
 
 (defmacro org-babel-go-as-list (val)
@@ -89,7 +81,7 @@
 
 (defun org-babel-expand-body:go (body params &optional processed-params)
   "Expand BODY according to PARAMS, return the expanded body."
-  (let ((vars (ob-go-get-var params))
+  (let ((vars (org-babel-go-get-var params))
         (main-p (not (string= (cdr (assoc :main params)) "no")))
         (imports (or (cdr (assoc :imports params))
                      (org-babel-read (org-entry-get nil "imports" t))))
@@ -143,7 +135,7 @@ called by `org-babel-execute-src-block'"
         (with-temp-file tmp-src-file (insert full-body))
         (org-babel-eval
          (format "%s run %s \"%s\" %s"
-                 org-babel-go-compiler
+                 org-babel-go-command
                  (mapconcat 'identity (org-babel-go-as-list flags) " ")
                  (org-babel-process-file-name tmp-src-file)
                  (mapconcat #'(lambda (a)
@@ -182,6 +174,14 @@ support for sessions"
     (if (string-match-p "^[ \t]*package" body)
         ""
       "package main")))
+
+(defun org-babel-go-get-var (params)
+  "org-babel-get-header was removed in org version 8.3.3"
+  (let* ((fversion (org-version))
+        (version (string-to-int fversion)))
+    (if (< version 8.3)
+        (mapcar #'cdr (org-babel-get-header params :var))
+      (org-babel--get-vars params))))
 
 (defun org-babel-go-gofmt (body)
   "Run gofmt over the body. Why not?"

--- a/ob-go.el
+++ b/ob-go.el
@@ -46,7 +46,7 @@
 ;;; Requirements:
 
 ;; - You must have go1 installed and the go should be in your `exec-path'. If
-;;   not, feel free to modify `org-babel-go-command' to the location of your
+;;   not, feel free to modify `org-babel-go-compiler' to the location of your
 ;;   go command.
 ;;
 ;; - `go-mode' is also needed for syntax highlighting and formatting. Not this
@@ -62,7 +62,7 @@
 ;;   package declaration.
 
 ;;; Code:
-(require 'go-mode)
+;;;(require 'go-mode)
 (require 'org)
 (require 'ob)
 (require 'ob-eval)
@@ -74,7 +74,7 @@
 
 (defvar org-babel-default-header-args:go '())
 
-(defvar org-babel-go-command "go"
+(defvar org-babel-go-compiler "go"
   "The go command to use to compile and run the go code.")
 
 (defmacro org-babel-go-as-list (val)
@@ -82,7 +82,7 @@
 
 (defun org-babel-expand-body:go (body params &optional processed-params)
   "Expand BODY according to PARAMS, return the expanded body."
-  (let ((vars (mapcar #'cdr (org-babel-get-header params :var)))
+  (let ((vars (mapcar #'cdr (org-babel--get-vars params)))
         (main-p (not (string= (cdr (assoc :main params)) "no")))
         (imports (or (cdr (assoc :imports params))
                      (org-babel-read (org-entry-get nil "imports" t))))
@@ -136,7 +136,7 @@ called by `org-babel-execute-src-block'"
         (with-temp-file tmp-src-file (insert full-body))
         (org-babel-eval
          (format "%s run %s \"%s\" %s"
-                 org-babel-go-command
+                 org-babel-go-compiler
                  (mapconcat 'identity (org-babel-go-as-list flags) " ")
                  (org-babel-process-file-name tmp-src-file)
                  (mapconcat #'(lambda (a)
@@ -202,6 +202,19 @@ specifying a var of the same value."
   "If the results look like a table, then convert them into an
 Emacs-lisp table, otherwise return the results as a string."
   (org-babel-script-escape results))
+
+;; Unit Testing
+
+(defvar org-babel-go-runtests nil)
+
+(eval-when-compile
+  ;; skips tests if go isn't correctly installed
+  (let ((go-version (shell-command-to-string "go version")))
+    (setq org-babel-go-runtests (string-match "go version .*" go-version))))
+
+;; (not  (or (string-match ".* command not found" (shell-command-to-string "go2 version"))
+;;           (string-match ".*not found" go-version)))
+
 
 (provide 'ob-go)
 ;;; ob-go.el ends here

--- a/test-ob-go.el
+++ b/test-ob-go.el
@@ -59,35 +59,35 @@
 
 (ert-deftest ob-go/simple-program ()
   "Hello world program."
-  (if (executable-find org-babel-go-compiler)
+  (if (executable-find org-babel-go-command)
       (org-test-at-id "412a86b1-644a-45b8-9e6d-bdc2b42d7e20"
 		      (org-babel-next-src-block 1)
 		      (should (= 42 (org-babel-execute-src-block))))))
 
 (ert-deftest ob-go/integer-var ()
   "Test of an integer variable."
-  (if (executable-find org-babel-go-compiler)
+  (if (executable-find org-babel-go-command)
       (org-test-at-id "412a86b1-644a-45b8-9e6d-bdc2b42d7e20"
 		      (org-babel-next-src-block 2)
 		      (should (= 12 (org-babel-execute-src-block))))))
 
 (ert-deftest ob-go/two-variables ()
   "Test of two integer variables."
-  (if (executable-find org-babel-go-compiler)
+  (if (executable-find org-babel-go-command)
       (org-test-at-id "412a86b1-644a-45b8-9e6d-bdc2b42d7e20"
 		      (org-babel-next-src-block 3)
 		      (should (= 666 (org-babel-execute-src-block))))))
 
 (ert-deftest ob-go/string-variables ()
   "Test the usage of string variables."
-  (if (executable-find org-babel-go-compiler)
+  (if (executable-find org-babel-go-command)
       (org-test-at-id "412a86b1-644a-45b8-9e6d-bdc2b42d7e20"
 		      (org-babel-next-src-block 4)
 		      (should (string-equal "golang" (org-babel-execute-src-block))))))
 
 (ert-deftest ob-go/table ()
   "Test of a table output."
-  (if (executable-find org-babel-go-compiler)
+  (if (executable-find org-babel-go-command)
       (org-test-at-id "1e9cf4e3-02df-4f3c-8533-2c0b1ca0a25a"
 		      (org-babel-next-src-block 1)
 		      (should (equal '((1) (2)) (org-babel-execute-src-block))))))
@@ -95,7 +95,7 @@
 ;; ob-go doesn't handle list variables yet
 ;; (ert-deftest ob-go/list-var ()
 ;;   "Test of a list input variable"
-;;   (if (executable-find org-babel-go-compiler)
+;;   (if (executable-find org-babel-go-command)
 ;;       (org-test-at-id "15000dad-5af1-45e3-ac80-a371335866dc"
 ;; 		      (org-babel-next-src-block 1)
 ;; 		      (should (string= "abcdef2" (org-babel-execute-src-block))))))

--- a/test-ob-go.el
+++ b/test-ob-go.el
@@ -1,0 +1,76 @@
+;;; test-ob-go.el --- tests for ob-go.el
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Code:
+(require 'org-id)
+(require 'cl)
+(require 'ox)
+
+(defconst ob-go-test-dir
+  (expand-file-name (file-name-directory (or load-file-name buffer-file-name))))
+
+(defconst org-id-locations-file
+  (expand-file-name ".test-org-id-locations" ob-go-test-dir))
+
+(defun ob-go-test-update-id-locations ()
+  (org-id-update-id-locations
+   (directory-files
+    ob-go-test-dir 'full
+    "^\\([^.]\\|\\.\\([^.]\\|\\..\\)\\).*\\.org$")))
+
+(defmacro org-test-at-id (id &rest body)
+  "Run body after placing the point in the headline identified by ID."
+  (declare (indent 1))
+  `(let* ((id-location (org-id-find ,id))
+	  (id-file (car id-location))
+	  (visited-p (get-file-buffer id-file))
+	  to-be-removed)
+     (unwind-protect
+	 (save-window-excursion
+	   (save-match-data
+	     (org-id-goto ,id)
+	     (setq to-be-removed (current-buffer))
+	     (condition-case nil
+		 (progn
+		   (org-show-subtree)
+		   (org-show-block-all))
+	       (error nil))
+	     (save-restriction ,@body)))
+       (unless (or visited-p (not to-be-removed))
+	 (kill-buffer to-be-removed)))))
+(def-edebug-spec org-test-at-id (form body))
+
+(defun ob-go-test-runall ()
+  (interactive)
+  (progn
+    (ob-go-test-update-id-locations)
+    (ert t)))
+
+(unless (featurep 'ob-go)
+  (signal 'missing-test-dependency "Support for Go code blocks"))
+
+(ert-deftest ob-go/assert ()
+  (should t))
+
+(ert-deftest ob-go/simple-program ()
+  "Hello world program."
+  (if (executable-find org-babel-go-compiler)
+      (org-test-at-id "412a86b1-644a-45b8-9e6d-bdc2b42d7e20"
+		      (org-babel-next-src-block 1)
+		      (should (= 42 (org-babel-execute-src-block))))))
+
+(provide 'ob-go-test)

--- a/test-ob-go.org
+++ b/test-ob-go.org
@@ -1,0 +1,9 @@
+#+OPTIONS: ^:nil
+* Simple tests
+  :PROPERTIES:
+  :ID:       412a86b1-644a-45b8-9e6d-bdc2b42d7e20
+  :END:
+#+source: simple
+#+begin_src go :imports "fmt" :results silent
+  fmt.Printf("42");
+#+end_src

--- a/test-ob-go.org
+++ b/test-ob-go.org
@@ -5,5 +5,44 @@
   :END:
 #+source: simple
 #+begin_src go :imports "fmt" :results silent
-  fmt.Printf("42");
+    fmt.Printf("42");
 #+end_src
+
+#+source: integer-var
+#+begin_src go :var q=12 :imports "fmt" :results silent
+    fmt.Print(q)
+#+end_src
+
+#+source: two-variables
+#+begin_src go :var q=333 :var p=333 :imports "fmt" :results silent
+    fmt.Print(q+p)
+#+end_src
+
+#+source: string-var
+#+begin_src go :var q="golang" :tangle string-var.go :imports "fmt" :results silent
+    fmt.Print(q)
+#+end_src
+
+* Array
+  :PROPERTIES:
+  :ID:       1e9cf4e3-02df-4f3c-8533-2c0b1ca0a25a
+  :END:
+#+source: array
+#+BEGIN_SRC go :imports "fmt" :results vector :results silent
+for i := 1; i < 3; i++ {
+	fmt.Printf("%d\n", i)
+}
+#+END_SRC
+
+* Matrix
+  :PROPERTIES:
+  :ID:       15000dad-5af1-45e3-ac80-a371335866dc
+  :END:
+#+name: Go-matrix
+| 1 | 2 |
+| 3 | 4 |
+
+#+source: list-var
+#+BEGIN_SRC go :var a='("abc" "def") :imports "fmt" :results silent
+fmt.Printf("%s\n", a[0] + a[1] + string(len(a)))
+#+END_SRC


### PR DESCRIPTION
Hello,

I added some unit testing to make sure everything is working as expected. This way it's much more easy to add the missing features without breaking the existing ones.

I've interest in implement the list and matrix option for variables. I'm using `ob-go` on a big literate software.

The tests use the Emacs ERT built in package for testing, then no dependencies are required for Emacs >= 24. The way it was tested is the same as orgmode core tests are implemented, using org-id to look for code blocks in a org file. In the future, if you have interest in add ob-go to orgmode repository, the task will be trivial.

The macro `org-test-at-id` was copied from `~/org/testing/org-test.el`, it makes the magic of find the correct code block in the org test file.

I made two changes in the ob-go.el  file:
1. The name of the variable `org-babel-go-command` was changed to `org-babel-go-compiler` for consistency with others babel implementations.
2. The function `ob-go-get-var` was created for compatibility between orgmode 8.2 and >= 8.3, because the function `org-babel-get-header` was removed in the last version.
- I created a makefile with a test rule;
- Added some info in README about the testing (maybe someone else interested in contribute can find useful);

Let me know if something is not good or if it caused some problem on your environment.

[]'s 
