### PR TITLE
Improve handling of 'output' type of result

### DIFF
--- a/ob-go.el
+++ b/ob-go.el
@@ -93,10 +93,10 @@
                  (list
                   ;; package
                   (org-babel-go-ensure-package body package)
+
                   ;; imports
-                  (mapconcat #'(lambda (pkg) (format "import %S" pkg))
-                             (org-babel-go-as-list imports)
-                             "\n")
+                  (org-babel-go-insert-imports imports)
+
                   ;; variables
                   (mapconcat 'org-babel-go-var-to-go vars "\n")
                   ;; body
@@ -174,6 +174,11 @@ support for sessions"
     (if (string-match-p "^[ \t]*package" body)
         ""
       "package main")))
+
+(defun org-babel-go-insert-imports (imports)
+  (mapconcat #'(lambda (pkg) (format "import %S" pkg))
+                             (org-babel-go-as-list imports)
+                             "\n"))
 
 (defun org-babel-go-get-var (params)
   "org-babel-get-header was removed in org version 8.3.3"

--- a/ob-go.el
+++ b/ob-go.el
@@ -125,7 +125,7 @@ called by `org-babel-execute-src-block'"
             (let ((tmp-file (org-babel-temp-file "go-")))
               (with-temp-file tmp-file (insert results))
               (org-babel-import-elisp-from-file tmp-file))
-          (org-babel-go-table-or-string results))
+          (org-babel-read results t))
         (org-babel-pick-name
 	 (cdr (assoc :colname-names params)) (cdr (assoc :colnames params)))
 	(org-babel-pick-name
@@ -176,9 +176,13 @@ support for sessions"
       "package main")))
 
 (defun org-babel-go-insert-imports (imports)
-  (mapconcat #'(lambda (pkg) (format "import %S" pkg))
+  (concat "import ("
+          "\n\t"
+          (mapconcat #'(lambda (pkg) (format "%S" pkg))
                              (org-babel-go-as-list imports)
-                             "\n"))
+                             "\t\n")
+          "\n)"
+          "\n"))
 
 (defun org-babel-go-get-var (params)
   "org-babel-get-header was removed in org version 8.3.3"
@@ -209,11 +213,6 @@ specifying a var of the same value."
       (setq val (symbol-name val)))
     ;; TODO(pope): Handle tables and lists.
     (format "var %S = %S" var val)))
-
-(defun org-babel-go-table-or-string (results)
-  "If the results look like a table, then convert them into an
-Emacs-lisp table, otherwise return the results as a string."
-  (org-babel-script-escape results))
 
 (provide 'ob-go)
 ;;; ob-go.el ends here

--- a/test-ob-go.el
+++ b/test-ob-go.el
@@ -78,11 +78,18 @@
 		      (org-babel-next-src-block 3)
 		      (should (= 666 (org-babel-execute-src-block))))))
 
+(ert-deftest ob-go/two-variables2 ()
+  "Test of two integer variables."
+  (if (executable-find org-babel-go-command)
+      (org-test-at-id "412a86b1-644a-45b8-9e6d-bdc2b42d7e20"
+		      (org-babel-next-src-block 4)
+		      (should (= 666 (org-babel-execute-src-block))))))
+
 (ert-deftest ob-go/string-variables ()
   "Test the usage of string variables."
   (if (executable-find org-babel-go-command)
       (org-test-at-id "412a86b1-644a-45b8-9e6d-bdc2b42d7e20"
-		      (org-babel-next-src-block 4)
+		      (org-babel-next-src-block 5)
 		      (should (string-equal "golang" (org-babel-execute-src-block))))))
 
 (ert-deftest ob-go/table ()
@@ -99,6 +106,21 @@
 ;;       (org-test-at-id "15000dad-5af1-45e3-ac80-a371335866dc"
 ;; 		      (org-babel-next-src-block 1)
 ;; 		      (should (string= "abcdef2" (org-babel-execute-src-block))))))
+
+(ert-deftest ob-go/imports ()
+  "Test the imports option"
+  (if (executable-find org-babel-go-command)
+      (org-test-at-id "e1aaec56-f3c6-4187-a003-5530b3ba956d"
+                      (org-babel-next-src-block 1)
+                      (should (= 3.141592653589793
+                                 (org-babel-execute-src-block))))))
+
+(ert-deftest ob-go/packages ()
+  (if (executable-find org-babel-go-command)
+      (org-test-at-id "c44f7afe-d356-4293-ba83-9ac71c7e6049"
+                      (org-babel-next-src-block 1)
+                      (should (string-equal "works"
+                                            (org-babel-execute-src-block))))))
 
 (defun ob-go-test-runall ()
   (progn

--- a/test-ob-go.el
+++ b/test-ob-go.el
@@ -123,6 +123,14 @@
                       (should (string-equal "works"
                                             (org-babel-execute-src-block))))))
 
+(ert-deftest ob-go/regression1 ()
+  (if (executable-find org-babel-go-command)
+      (org-test-at-id "3f63c93d-6f17-478d-9817-e5c24a696689"
+                      (org-babel-next-src-block 1)
+                      (should (string-equal "'h' and 'i'"
+                                            (org-babel-execute-src-block))))))
+
+
 (defun ob-go-test-runall ()
   (progn
     (ob-go-test-update-id-locations)

--- a/test-ob-go.org
+++ b/test-ob-go.org
@@ -53,6 +53,7 @@ for i := 1; i < 3; i++ {
 #+BEGIN_SRC go :var a='("abc" "def") :imports "fmt" :results silent
 fmt.Printf("%s\n", a[0] + a[1] + string(len(a)))
 #+END_SRC
+
 * Imports
   :PROPERTIES:
   :ID:       e1aaec56-f3c6-4187-a003-5530b3ba956d

--- a/test-ob-go.org
+++ b/test-ob-go.org
@@ -68,14 +68,11 @@ fmt.Printf("%v", math.Pi)
   :END:
 
 #+source: package
-#+BEGIN_SRC go :main no :package main :imports "fmt"
+#+BEGIN_SRC go :main no :package main :imports "fmt" :results silent
 func main() {
         fmt.Printf("works")
 }
 #+END_SRC
-
-#+RESULTS: package
-: works
 
 * Regression tests
   :PROPERTIES:

--- a/test-ob-go.org
+++ b/test-ob-go.org
@@ -5,7 +5,7 @@
   :END:
 #+source: simple
 #+BEGIN_SRC go :imports "fmt" :results silent
-    fmt.Printf("42");
+    fmt.Printf("42")
 #+END_SRC
 
 #+source: integer-var
@@ -72,4 +72,17 @@ fmt.Printf("%v", math.Pi)
 func main() {
         fmt.Printf("works")
 }
+#+END_SRC
+
+#+RESULTS: package
+: works
+
+* Regression tests
+  :PROPERTIES:
+  :ID:       3f63c93d-6f17-478d-9817-e5c24a696689
+  :END:
+
+#+BEGIN_SRC go :imports "fmt" :results silent
+    s := "'h' and 'i'"
+    fmt.Printf("%s\n", s)
 #+END_SRC

--- a/test-ob-go.org
+++ b/test-ob-go.org
@@ -4,24 +4,31 @@
   :ID:       412a86b1-644a-45b8-9e6d-bdc2b42d7e20
   :END:
 #+source: simple
-#+begin_src go :imports "fmt" :results silent
+#+BEGIN_SRC go :imports "fmt" :results silent
     fmt.Printf("42");
-#+end_src
+#+END_SRC
 
 #+source: integer-var
-#+begin_src go :var q=12 :imports "fmt" :results silent
+#+BEGIN_SRC go :var q=12 :imports "fmt" :results silent
     fmt.Print(q)
-#+end_src
+#+END_SRC
 
 #+source: two-variables
-#+begin_src go :var q=333 :var p=333 :imports "fmt" :results silent
+#+BEGIN_SRC go :var q=333 :var p=333 :imports "fmt" :results silent
     fmt.Print(q+p)
-#+end_src
+#+END_SRC
+
+#+source: two-variables2
+#+HEADER: :var q=333
+#+HEADER: :var p=333
+#+BEGIN_SRC go :imports "fmt" :results silent
+    fmt.Print(q+p)
+#+END_SRC
 
 #+source: string-var
-#+begin_src go :var q="golang" :tangle string-var.go :imports "fmt" :results silent
+#+BEGIN_SRC go :var q="golang" :imports "fmt" :results silent
     fmt.Print(q)
-#+end_src
+#+END_SRC
 
 * Array
   :PROPERTIES:
@@ -45,4 +52,24 @@ for i := 1; i < 3; i++ {
 #+source: list-var
 #+BEGIN_SRC go :var a='("abc" "def") :imports "fmt" :results silent
 fmt.Printf("%s\n", a[0] + a[1] + string(len(a)))
+#+END_SRC
+* Imports
+  :PROPERTIES:
+  :ID:       e1aaec56-f3c6-4187-a003-5530b3ba956d
+  :END:
+#+source: imports
+#+BEGIN_SRC go :imports '("fmt" "math") :results silent
+fmt.Printf("%v", math.Pi)
+#+END_SRC
+
+* Package
+  :PROPERTIES:
+  :ID:       c44f7afe-d356-4293-ba83-9ac71c7e6049
+  :END:
+
+#+source: package
+#+BEGIN_SRC go :main no :package main :imports "fmt"
+func main() {
+        fmt.Printf("works")
+}
 #+END_SRC


### PR DESCRIPTION
I added some more testing and a fix for issue #1. But the fix was very straightforward, the correct way (I think) is using the modern macro `org-babel-result-cond` (or implement the same logic in our side), but it does not exists in org < 8.3. My fix avoids any elisp interpretation of output when :results does not contains vector or table. I really don't see the point of `org-babel-go-table-or-string`.

I added a cosmetic change to 'imports` output too. 

Before:

``` go
package main
import "fmt"
import "math"
import "crypt"
```

Now:

``` go
package main
import (
        "fmt"
        "math"
        "crypt"
)
```

Let me know what I should improve.

Closes #1 
