### PR TITLE
org-babel--get-vars not defined in orgmode<=8.3.4

### DIFF
--- a/ob-go.el
+++ b/ob-go.el
@@ -185,7 +185,7 @@ support for sessions"
           "\n"))
 
 (defun org-babel-go-get-var (params)
-  "org-babel-get-header in newer versions of org (master branch)"
+  "org-babel-get-header was removed in newer versions of org (master branch)"
   (if (fboundp 'org-babel-get-header)
       (mapcar #'cdr (org-babel-get-header params :var))
     (org-babel--get-vars params)))

--- a/ob-go.el
+++ b/ob-go.el
@@ -186,11 +186,9 @@ support for sessions"
 
 (defun org-babel-go-get-var (params)
   "org-babel-get-header was removed in org version 8.3.3"
-  (let* ((fversion (org-version))
-        (version (string-to-int fversion)))
-    (if (< version 8.3)
-        (mapcar #'cdr (org-babel-get-header params :var))
-      (org-babel--get-vars params))))
+  (if (fboundp 'org-babel-get-header)
+      (mapcar #'cdr (org-babel-get-header params :var))
+    (org-babel--get-vars params)))
 
 (defun org-babel-go-gofmt (body)
   "Run gofmt over the body. Why not?"

--- a/ob-go.el
+++ b/ob-go.el
@@ -185,7 +185,7 @@ support for sessions"
           "\n"))
 
 (defun org-babel-go-get-var (params)
-  "org-babel-get-header was removed in org version 8.3.3"
+  "org-babel-get-header in newer versions of org (master branch)"
   (if (fboundp 'org-babel-get-header)
       (mapcar #'cdr (org-babel-get-header params :var))
     (org-babel--get-vars params)))


### PR DESCRIPTION
The function `org-babel--get-vars` is only defined in the master branch (orgmode 9.0).

Add a simple check verifying if `org-babel-get-header` exists and only
use `org-babel--get-vars` otherwise.

Closes #10
