### PR TITLE
added 'discard value for :package key 

### DIFF
--- a/ob-go.el
+++ b/ob-go.el
@@ -157,8 +157,9 @@ support for sessions"
     (concat "func main() {\n" body "\n}\n")))
 
 (defun org-babel-go-append-package (package)
-  "Check to see if package is set. If not, add main."
-  (concat "package " (if (and package (not (string-empty-p package))) package "main")))
+  "Check to see if package is set. If not, add main unless there is a 'discard value for the package key (allows to tangle many source blocks into one go project)."
+  (unless (eq package 'discard)
+    (concat "package " (if (and package (not (string-empty-p package))) package "main"))))
 
 (defun org-babel-go-ensure-package (body package)
   "Ensure package exists."


### PR DESCRIPTION
Allows to discard package declaration during tangling. Enables splitting one package into several source blocks and thus literate programming approach.

Example:

```
#+begin_src go :main no :tangle ~/go/project/path/tangled.go :imports "fmt" :package custom
// some code
#+end_src

Some text in Org buffer.

#+begin_src go :main no :tangle ~/go/project/path/tangled.go :package 'discard
// some code
#+end_src

Etc.
```

Tangles to:

```
package custom

import "fmt"

//some code

//some code... without another package declaration preceding
```
