### PR TITLE
remove require for 'org', 'ob-eval' and 'ob-ref'

### DIFF
--- a/ob-go.el
+++ b/ob-go.el
@@ -62,10 +62,7 @@
 ;;   package declaration.
 
 ;;; Code:
-(require 'org)
 (require 'ob)
-(require 'ob-eval)
-(require 'ob-ref)
 
 
 ;; optionally define a file extension for this language

--- a/ob-go.el
+++ b/ob-go.el
@@ -62,7 +62,7 @@
 ;;   package declaration.
 
 ;;; Code:
-(require 'ob)
+(require 'ob-tangle)
 
 
 ;; optionally define a file extension for this language


### PR DESCRIPTION
- 'org' is not used in this package
- 'ob-eval' and 'ob-ref' are already reqired in 'ob' package